### PR TITLE
Restore article hero image and Facebook preview image

### DIFF
--- a/_includes/layout_head.html
+++ b/_includes/layout_head.html
@@ -1,4 +1,28 @@
 {% assign title_extra = page.title | default: site.title | strip_html %}
+{% assign meta_description = page.summary | default: page.excerpt | default: page.description | default: site.description | strip_html | strip_newlines | strip %}
+{% assign meta_site_url = site.url | default: "" | strip %}
+{% if meta_site_url == "" %}
+  {% assign meta_site_url = "https://www.freesoftwaremagazine.com" %}
+{% endif %}
+{% assign meta_page_url = page.url | default: "/" %}
+{% assign canonical_url = meta_site_url | append: meta_page_url %}
+{% assign raw_main_image = page.main_image | default: "" | strip %}
+{% assign meta_main_image = raw_main_image | replace: " ", "%20" %}
+{% assign main_image_first_char = meta_main_image | slice: 0, 1 %}
+{% assign og_image = "" %}
+{% if meta_main_image != "" %}
+  {% if meta_main_image contains "://" %}
+    {% assign og_image = meta_main_image %}
+  {% elsif main_image_first_char == "/" %}
+    {% assign og_image = meta_site_url | append: meta_main_image %}
+  {% else %}
+    {% assign og_image = canonical_url | append: meta_main_image %}
+  {% endif %}
+{% endif %}
+{% assign og_type = "website" %}
+{% if page.layout == "article" or page.path contains "articles/" %}
+  {% assign og_type = "article" %}
+{% endif %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -15,6 +39,31 @@
     <meta name="theme-color" content="#ffffff">
 
     <title>{{ title_extra }}</title>
+    <link rel="canonical" href="{{ canonical_url }}">
+    {% if meta_description != "" %}
+      <meta name="description" content="{{ meta_description }}">
+    {% endif %}
+    <meta property="og:title" content="{{ title_extra }}">
+    <meta property="og:type" content="{{ og_type }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    {% if site.title %}
+      <meta property="og:site_name" content="{{ site.title }}">
+    {% endif %}
+    {% if meta_description != "" %}
+      <meta property="og:description" content="{{ meta_description }}">
+    {% endif %}
+    {% if og_image != "" %}
+      <meta property="og:image" content="{{ og_image }}">
+      <meta property="og:image:alt" content="{{ title_extra }}">
+      <meta name="twitter:card" content="summary_large_image">
+      <meta name="twitter:image" content="{{ og_image }}">
+    {% else %}
+      <meta name="twitter:card" content="summary">
+    {% endif %}
+    <meta name="twitter:title" content="{{ title_extra }}">
+    {% if meta_description != "" %}
+      <meta name="twitter:description" content="{{ meta_description }}">
+    {% endif %}
 
     <link rel="stylesheet" href="/assets/css/main.css">
   </head>

--- a/_includes/layout_head.html
+++ b/_includes/layout_head.html
@@ -66,6 +66,7 @@
     {% endif %}
 
     <link rel="stylesheet" href="/assets/css/main.css">
+    <link rel="stylesheet" href="/assets/css/custom.css">
   </head>
   <body>
     {% include navbar.html %}

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -58,15 +58,14 @@
       {% endif %}
     </ul>
 
-    {% assign article_main_image = page.main_image | default: "" | strip %}
-    {% if article_main_image != "" %}
-      {% assign article_main_image_path = article_main_image | replace: " ", "%20" %}
-      <figure class="figure mb-4">
-        <img class="figure-img img-fluid rounded" src="{{ article_main_image_path }}" alt="{{ page.title | strip_html }}">
-      </figure>
-    {% endif %}
-
     <div class="article-content">
+      {% assign article_main_image = page.main_image | default: "" | strip %}
+      {% if article_main_image != "" %}
+        {% assign article_main_image_path = article_main_image | replace: " ", "%20" %}
+        <figure class="article-hero figure mb-4">
+          <img class="figure-img img-fluid rounded" src="{{ article_main_image_path }}" alt="{{ page.title | strip_html }}">
+        </figure>
+      {% endif %}
       {{ content }}
     </div>
 

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -58,6 +58,14 @@
       {% endif %}
     </ul>
 
+    {% assign article_main_image = page.main_image | default: "" | strip %}
+    {% if article_main_image != "" %}
+      {% assign article_main_image_path = article_main_image | replace: " ", "%20" %}
+      <figure class="figure mb-4">
+        <img class="figure-img img-fluid rounded" src="{{ article_main_image_path }}" alt="{{ page.title | strip_html }}">
+      </figure>
+    {% endif %}
+
     <div class="article-content">
       {{ content }}
     </div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,30 @@
+.article-content::after {
+  clear: both;
+  content: "";
+  display: block;
+}
+
+.article-hero {
+  display: block;
+  float: right;
+  margin: 0 0 1rem 1.5rem;
+  max-width: 420px;
+  min-width: 220px;
+  width: 45%;
+}
+
+.article-hero .figure-img {
+  display: block;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  .article-hero {
+    float: none;
+    margin: 0 0 1rem;
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/scripts/validate_site_integrity.rb
+++ b/scripts/validate_site_integrity.rb
@@ -240,6 +240,29 @@ end
 checks << ["legacy markers in rendered articles", legacy_marker_hits, 0]
 checks << ["unprocessed directives in rendered articles", unprocessed_directive_hits, 0]
 
+# Social preview + in-article hero image check on newest listed article with main_image
+latest_with_main_image = listed_sorted.find do |article|
+  !blank_value?(article[:data]["main_image"])
+end
+
+if latest_with_main_image
+  slug = latest_with_main_image[:slug]
+  main_image = latest_with_main_image[:data]["main_image"].to_s.strip.gsub(" ", "%20")
+  article_html_path = File.join(SITE, "articles", slug, "index.html")
+
+  if File.file?(article_html_path)
+    html = File.read(article_html_path)
+    expected_image_url_fragment = "/articles/#{slug}/#{main_image}"
+    expected_hero_fragment = %(<img class="figure-img img-fluid rounded" src="#{main_image}")
+
+    checks << ["social og:image present", html.include?('property="og:image"'), true]
+    checks << ["social og:image URL", html.include?(expected_image_url_fragment), true]
+    checks << ["article hero image present", html.include?(expected_hero_fragment), true]
+  else
+    checks << ["social article html exists", false, true]
+  end
+end
+
 checks.each do |name, actual, expected|
   if actual == expected
     puts "OK   #{name}: #{actual}"


### PR DESCRIPTION
This fixes social/article image regressions by restoring main image rendering on article pages and adding Open Graph/Twitter metadata.

Changes:
- `_layouts/article.html`: render `main_image` at top of article body
- `_includes/layout_head.html`: add canonical URL + OG/Twitter tags (`og:title`, `og:url`, `og:type`, `og:image`, `twitter:image`, etc.)
- `scripts/validate_site_integrity.rb`: add checks to ensure newest listed article with `main_image` has both `og:image` and in-article hero image

Validation:
- `npm run check` passed