### PR TITLE
Improve metadata + add Facebook domain verification tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Free Software Magazine
-description: Static site migration scaffold for Jekyll.
+description: Free Software Magazine is a mostly free-content online magazine about free software.
 baseurl: ""
-url: ""
+url: "https://www.freesoftwaremagazine.com"
 
 markdown: kramdown
 permalink: pretty

--- a/_includes/layout_head.html
+++ b/_includes/layout_head.html
@@ -1,5 +1,7 @@
 {% assign title_extra = page.title | default: site.title | strip_html %}
-{% assign meta_description = page.summary | default: page.excerpt | default: page.description | default: site.description | strip_html | strip_newlines | strip %}
+{% assign page_summary = page["summary"] | default: page.summary %}
+{% assign page_description = page["description"] | default: page.description %}
+{% assign meta_description = page_summary | default: page_description | default: site.description | strip_html | strip_newlines | strip %}
 {% assign meta_site_url = site.url | default: "" | strip %}
 {% if meta_site_url == "" %}
   {% assign meta_site_url = "https://www.freesoftwaremagazine.com" %}
@@ -29,6 +31,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="facebook-domain-verification" content="7e4zwukkjtqszaa2lm7alpntgppvae">
 
     <!-- Favicons: Thanks http://realfavicongenerator.net ! -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
- Set canonical site URL and production description in _config.yml
- Populate article summary/description defaults at generator time
- Use clean summary/description fallback chain in layout head
- Add Facebook domain verification meta tag in <head>