### PR TITLE
Polish Books UX, Captions, and Analytics

### DIFF
--- a/_includes/article_card.html
+++ b/_includes/article_card.html
@@ -2,18 +2,22 @@
 {% assign url = article.url %}
 {% assign img = article.main_image | default: "" %}
 {% assign img_path = img | replace: " ", "%20" %}
+{% assign card_image_url = "/assets/images/article-no-image-placeholder.svg" %}
+{% assign card_image_is_placeholder = true %}
+{% if img != "" %}
+  {% assign card_image_url = url | append: img_path %}
+  {% assign card_image_is_placeholder = false %}
+{% endif %}
 {% assign date_value = article.published | default: article.date %}
 {% assign sections = article.section | default: "" | split: "," %}
 {% assign authors = article.authors | default: "" | split: "," %}
 
 <div class="card article-card">
-  {% if img != "" %}
-    <a href="{{ url }}">
-      <div class="card-img-top embed-responsive embed-responsive-3by4 article-card-img">
-        <div class="embed-responsive-item article-card-img-item" style="background-image: url('{{ url }}{{ img_path }}')"></div>
-      </div>
-    </a>
-  {% endif %}
+  <a href="{{ url }}">
+    <div class="card-img-top embed-responsive embed-responsive-3by4 article-card-img">
+      <div class="embed-responsive-item article-card-img-item{% if card_image_is_placeholder %} article-card-img-item-placeholder{% endif %}" style="background-image: url('{{ card_image_url }}')"></div>
+    </div>
+  </a>
   <div class="card-block article-card-block">
     {% if article.section %}
       <p class="article-card-sectionname">

--- a/_includes/book_chapter_nav.html
+++ b/_includes/book_chapter_nav.html
@@ -1,0 +1,29 @@
+{% if page.book_nav_list_url %}
+  <nav class="book-nav my-3" aria-label="Book chapter navigation">
+    <div class="book-nav-grid">
+      <div class="book-nav-item book-nav-prev">
+        {% if page.book_nav_prev_url %}
+          <a class="book-nav-link" href="{{ page.book_nav_prev_url }}">
+            <span class="book-nav-label">Previous chapter</span>
+            <span class="book-nav-title">&laquo; {{ page.book_nav_prev_title }}</span>
+          </a>
+        {% else %}
+          <span class="book-nav-placeholder" aria-hidden="true"></span>
+        {% endif %}
+      </div>
+      <div class="book-nav-item book-nav-all">
+        <a class="book-nav-link book-nav-link-center" href="{{ page.book_nav_list_url }}">All chapters</a>
+      </div>
+      <div class="book-nav-item book-nav-next">
+        {% if page.book_nav_next_url %}
+          <a class="book-nav-link" href="{{ page.book_nav_next_url }}">
+            <span class="book-nav-label">Next chapter</span>
+            <span class="book-nav-title">{{ page.book_nav_next_title }} &raquo;</span>
+          </a>
+        {% else %}
+          <span class="book-nav-placeholder" aria-hidden="true"></span>
+        {% endif %}
+      </div>
+    </div>
+  </nav>
+{% endif %}

--- a/_includes/layout_head.html
+++ b/_includes/layout_head.html
@@ -71,6 +71,15 @@
       <meta name="twitter:description" content="{{ meta_description }}">
     {% endif %}
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-PB52KLVTJ4"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-PB52KLVTJ4');
+    </script>
+
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="stylesheet" href="/assets/css/custom.css">
   </head>

--- a/_includes/paginated_article_list.html
+++ b/_includes/paginated_article_list.html
@@ -14,13 +14,50 @@
   </div>
 {% endif %}
 
-<div class="row {{ page.list_name }}">
-  {% for article in page.elements_in_this_page %}
-    <div class="col-sm-6 col-lg-4 mb-4">
-      {% include article_card.html article=article %}
-    </div>
-  {% endfor %}
-</div>
+{% if page.list_name == "books" %}
+  <div class="table-responsive">
+    <table class="table table-striped table-sm books-chapter-list">
+      <thead>
+        <tr>
+          <th scope="col">Chapter</th>
+          <th scope="col">Author</th>
+          <th scope="col">Published</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for article in page.elements_in_this_page %}
+          {% assign authors = article.authors | default: "" | split: "," %}
+          {% assign date_value = article.published | default: article.date %}
+          <tr>
+            <td><a href="{{ article.url }}">{{ article.title }}</a></td>
+            <td>
+              {% for author in authors %}
+                {% assign author_slug = author | strip %}
+                {% assign author_label = author_slug | replace: "_", " " %}
+                {% if author_slug != "" %}
+                  <a href="/authors/{{ author_slug | uri_escape }}">{{ author_label }}</a>
+                {% endif %}
+              {% endfor %}
+            </td>
+            <td>
+              {% if date_value %}
+                {{ date_value | date: "%-m/%-d/%Y" }}
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% else %}
+  <div class="row {{ page.list_name }}">
+    {% for article in page.elements_in_this_page %}
+      <div class="col-sm-6 col-lg-4 mb-4">
+        {% include article_card.html article=article %}
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}
 
 {% if page.total_pages and page.total_pages != 1 %}
   <nav aria-label="This article list spans multiple pages">

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -30,7 +30,8 @@
           {% for book in book_list %}
             {% assign book_name = book | strip %}
             {% if book_name != "" %}
-              <a href="/sections/{{ book_name | uri_escape }}">{{ book_name }}</a>
+              {% assign book_label = book_name | replace: "_", " " %}
+              <a href="/books/{{ book_name | uri_escape }}">{{ book_label }}</a>
             {% endif %}
           {% endfor %}
         {% endif %}
@@ -59,6 +60,7 @@
     </ul>
 
     <div class="article-content">
+      {% include book_chapter_nav.html %}
       {% assign article_main_image = page.main_image | default: "" | strip %}
       {% if article_main_image != "" %}
         {% assign article_main_image_path = article_main_image | replace: " ", "%20" %}
@@ -67,6 +69,7 @@
         </figure>
       {% endif %}
       {{ content }}
+      {% include book_chapter_nav.html %}
     </div>
 
     {% if page.license %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -4,6 +4,29 @@
   display: block;
 }
 
+.article-content figure.figure {
+  display: block;
+  margin: 1.6rem auto;
+  max-width: 100%;
+}
+
+.article-content figure.figure .figure-img {
+  background: #fff;
+  border: 1px solid #d7e5ef;
+  border-radius: 0.38rem;
+  box-shadow: 0 2px 7px rgba(30, 61, 86, 0.14);
+  display: block;
+  margin: 0 auto;
+}
+
+.article-content figure.figure .figure-caption {
+  color: #5e7485;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  margin-top: 0.55rem;
+  text-align: center;
+}
+
 .article-hero {
   display: block;
   float: right;
@@ -19,6 +42,13 @@
   width: 100%;
 }
 
+.article-card-img-item-placeholder {
+  background-color: #f3f7fa;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
 @media (max-width: 767px) {
   .article-hero {
     float: none;
@@ -26,5 +56,161 @@
     max-width: 100%;
     min-width: 0;
     width: 100%;
+  }
+}
+
+.books-index-list .list-group-item {
+  align-items: center;
+  display: flex;
+  font-size: 1.03rem;
+  justify-content: space-between;
+  min-height: 3rem;
+}
+
+.books-index-list .books-index-main {
+  display: flex;
+  flex-direction: column;
+}
+
+.books-index-list .books-index-title {
+  align-items: center;
+  display: inline-flex;
+}
+
+.books-index-list .books-index-title::before {
+  border: 2px solid #4b97c8;
+  border-radius: 2px;
+  box-shadow: inset 0.18rem 0 0 #d8ecf9;
+  content: "";
+  display: inline-block;
+  height: 1.02rem;
+  margin-right: 0.52rem;
+  width: 0.82rem;
+}
+
+.books-index-list .books-index-authors {
+  color: #6f8798;
+  font-size: 0.82rem;
+  letter-spacing: 0.015em;
+  margin-left: 1.34rem;
+  margin-top: 0.14rem;
+}
+
+.books-index-list .books-index-cta {
+  color: #4b97c8;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-left: 1rem;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.book-nav {
+  background: #f8fcff;
+  border: 1px solid #d9e8f2;
+  border-radius: 0.5rem;
+  padding: 0.55rem;
+}
+
+.book-nav-grid {
+  align-items: stretch;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 1fr auto 1fr;
+}
+
+.book-nav-prev {
+  text-align: left;
+}
+
+.book-nav-all {
+  align-self: center;
+  text-align: center;
+}
+
+.book-nav-next {
+  text-align: right;
+}
+
+.book-nav-link {
+  background: #fff;
+  border: 1px solid #d6e4ee;
+  border-radius: 0.4rem;
+  color: #2479ab;
+  display: block;
+  min-height: 100%;
+  padding: 0.45rem 0.6rem;
+  text-decoration: none;
+}
+
+.book-nav-link:hover,
+.book-nav-link:focus {
+  background: #edf7fd;
+  text-decoration: none;
+}
+
+.book-nav-label {
+  color: #7890a0;
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.1rem;
+  text-transform: uppercase;
+}
+
+.book-nav-title {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.book-nav-link-center {
+  font-weight: 600;
+  padding: 0.85rem 1rem;
+  white-space: nowrap;
+}
+
+.book-nav-placeholder {
+  background: #f8fcff;
+  border: 1px dashed #d6e4ee;
+  border-radius: 0.4rem;
+  display: block;
+  min-height: 3rem;
+}
+
+@media (max-width: 767px) {
+  .books-index-list .list-group-item {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .books-index-list .books-index-cta {
+    margin-left: 0;
+    margin-top: 0.15rem;
+  }
+
+  .books-index-list .books-index-authors {
+    margin-left: 0;
+  }
+
+  .book-nav-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .book-nav-prev,
+  .book-nav-next,
+  .book-nav-all {
+    text-align: left;
+  }
+
+  .book-nav-link-center {
+    text-align: center;
+  }
+
+  .book-nav-placeholder {
+    display: none;
   }
 }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -117,10 +117,15 @@
   align-items: stretch;
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+}
+
+.book-nav-item {
+  min-width: 0;
 }
 
 .book-nav-prev {
+  justify-self: start;
   text-align: left;
 }
 
@@ -130,6 +135,7 @@
 }
 
 .book-nav-next {
+  justify-self: end;
   text-align: right;
 }
 
@@ -162,9 +168,15 @@
 
 .book-nav-title {
   display: block;
+  line-height: 1.25;
+  max-height: 2.5em;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+}
+
+.book-nav-prev .book-nav-link,
+.book-nav-next .book-nav-link {
+  max-width: 26rem;
 }
 
 .book-nav-link-center {

--- a/assets/images/article-no-image-placeholder.svg
+++ b/assets/images/article-no-image-placeholder.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="800" viewBox="0 0 600 800" role="img" aria-labelledby="title desc">
+  <title id="title">No image available</title>
+  <desc id="desc">Placeholder illustration shown when an article has no hero image.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f7fbff"/>
+      <stop offset="100%" stop-color="#e6f0f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" fill="url(#bg)"/>
+  <rect x="74" y="90" width="452" height="620" rx="20" fill="#ffffff" stroke="#c6d8e6" stroke-width="4"/>
+  <rect x="120" y="180" width="360" height="280" rx="14" fill="#edf5fb" stroke="#bfd4e4" stroke-width="4"/>
+  <path d="M130 430L235 315L305 385L375 320L470 430Z" fill="#d9e9f4"/>
+  <circle cx="410" cy="245" r="34" fill="#d0e3f1"/>
+  <line x1="120" y1="520" x2="480" y2="520" stroke="#d4e3ef" stroke-width="10" stroke-linecap="round"/>
+  <line x1="120" y1="560" x2="400" y2="560" stroke="#dce9f3" stroke-width="10" stroke-linecap="round"/>
+  <text x="300" y="640" text-anchor="middle" font-family="Arial, sans-serif" font-size="33" fill="#5f7f95">No image available</text>
+</svg>

--- a/books/index.html
+++ b/books/index.html
@@ -5,23 +5,49 @@ title: Books
 
 <h3 class="text-center mb-4">Books</h3>
 
-<div class="row">
-  <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
-    {% include book_card.html url="/books/autotools_a_guide_to_autoconf_automake_libtool/" img="http://placehold.it/200x300" title="Autotools: a guide to Autoconf, Automake and Libtool" subtitle="" %}
-  </div>
-  <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
-    {% include book_card.html url="/books/free_software_vector_graphics_applications/" img="http://placehold.it/200x300" title="Free software vector graphics applications" subtitle="" %}
-  </div>
-  <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
-    {% include book_card.html url="/books/making_free_movies_with_free_software/" img="http://placehold.it/200x300" title="Making free movies with free software" subtitle="" %}
-  </div>
-  <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
-    {% include book_card.html url="/books/making_the_impossible_happen_the_rules_of_free_culture/" img="http://placehold.it/200x300" title="Making the impossible happen: the rules of free culture" subtitle="" %}
-  </div>
-  <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
-    {% include book_card.html url="/books/network_monitoring_with_zenoss/" img="http://placehold.it/200x300" title="Network monitoring with ZenOss" subtitle="" %}
-  </div>
-  <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
-    {% include book_card.html url="/books/ubuntu_applications/" img="http://placehold.it/200x300" title="Ubuntu applications" subtitle="" %}
-  </div>
+<p class="text-center text-muted mb-4">Serialized guides and long-form collections.</p>
+
+<div class="list-group books-index-list mb-4">
+  <a class="list-group-item list-group-item-action" href="/books/autotools_a_guide_to_autoconf_automake_libtool/">
+    <span class="books-index-main">
+      <span class="books-index-title">Autotools: a practitioner's guide to Autoconf, Automake and Libtool</span>
+      <span class="books-index-authors">By John Calcote</span>
+    </span>
+    <span class="books-index-cta">View chapters</span>
+  </a>
+  <a class="list-group-item list-group-item-action" href="/books/free_software_vector_graphics_applications/">
+    <span class="books-index-main">
+      <span class="books-index-title">Free software vector graphics applications</span>
+      <span class="books-index-authors">By Terry Hancock</span>
+    </span>
+    <span class="books-index-cta">View chapters</span>
+  </a>
+  <a class="list-group-item list-group-item-action" href="/books/making_free_movies_with_free_software/">
+    <span class="books-index-main">
+      <span class="books-index-title">Making free movies with free software</span>
+      <span class="books-index-authors">By Terry Hancock</span>
+    </span>
+    <span class="books-index-cta">View chapters</span>
+  </a>
+  <a class="list-group-item list-group-item-action" href="/books/making_the_impossible_happen_the_rules_of_free_culture/">
+    <span class="books-index-main">
+      <span class="books-index-title">Making the impossible happen: the rules of free culture</span>
+      <span class="books-index-authors">By Terry Hancock</span>
+    </span>
+    <span class="books-index-cta">View chapters</span>
+  </a>
+  <a class="list-group-item list-group-item-action" href="/books/network_monitoring_with_zenoss/">
+    <span class="books-index-main">
+      <span class="books-index-title">Network monitoring with Zenoss</span>
+      <span class="books-index-authors">By Terry Hancock</span>
+    </span>
+    <span class="books-index-cta">View chapters</span>
+  </a>
+  <a class="list-group-item list-group-item-action" href="/books/ubuntu_applications/">
+    <span class="books-index-main">
+      <span class="books-index-title">Ubuntu applications</span>
+      <span class="books-index-authors">By Andrew Min</span>
+    </span>
+    <span class="books-index-cta">View chapters</span>
+  </a>
 </div>

--- a/scripts/validate_site_integrity.rb
+++ b/scripts/validate_site_integrity.rb
@@ -253,11 +253,11 @@ if latest_with_main_image
   if File.file?(article_html_path)
     html = File.read(article_html_path)
     expected_image_url_fragment = "/articles/#{slug}/#{main_image}"
-    expected_hero_fragment = %(<img class="figure-img img-fluid rounded" src="#{main_image}")
+    hero_image_regex = /<img[^>]*class="[^"]*\bfigure-img\b[^"]*\bimg-fluid\b[^"]*\brounded\b[^"]*"[^>]*src="#{Regexp.escape(main_image)}"/m
 
     checks << ["social og:image present", html.include?('property="og:image"'), true]
     checks << ["social og:image URL", html.include?(expected_image_url_fragment), true]
-    checks << ["article hero image present", html.include?(expected_hero_fragment), true]
+    checks << ["article hero image present", !!(html =~ hero_image_regex), true]
   else
     checks << ["social article html exists", false, true]
   end


### PR DESCRIPTION
## Summary
- render `/books/` as a cleaner no-image list with book icons and author lines
- improve book chapter navigation (top/bottom prev/all/next)
- add fallback placeholder images in article list cards when `main_image` is missing
- improve figure styling and auto-fill missing legacy figure captions from filenames
- add Google Analytics gtag (`G-PB52KLVTJ4`) globally in the shared `<head>` include
- harden site-integrity hero-image check against multiline markup

## Validation
- `bundle exec jekyll build`
- `bundle exec ruby scripts/validate_site_integrity.rb`
