### PR TITLE
Improve table rendering and active navigation state

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -11,17 +11,23 @@
   </div>
 </nav>
 <nav class="navbar navbar-clear">
+  {% assign nav_url = page.url | default: "/" %}
+  {% assign nav_section = page.section | default: "" | split: "," | first | strip %}
+  {% assign url_section = nav_url | remove_first: "/sections/" | split: "/" | first %}
+  {% if nav_section == "" and nav_url contains "/sections/" %}
+    {% assign nav_section = url_section %}
+  {% endif %}
   <div class="container">
     <ul class="navbar-nav">
-      <li class="nav-item"><a class="nav-link" href="/sections/end_users">End users</a></li>
-      <li class="nav-item"><a class="nav-link" href="/sections/hacking">Hacking</a></li>
-      <li class="nav-item"><a class="nav-link" href="/sections/humour">Humour</a></li>
-      <li class="nav-item"><a class="nav-link" href="/sections/interviews">Interviews</a></li>
-      <li class="nav-item"><a class="nav-link" href="/sections/opinions">Opinons</a></li>
-      <li class="nav-item"><a class="nav-link" href="/sections/reviews">Reviews</a></li>
-      <li class="nav-item"><a class="nav-link" href="/all_articles/">All articles</a></li>
-      <li class="nav-item"><a class="nav-link" href="/issues/">Issues</a></li>
-      <li class="nav-item"><a class="nav-link" href="/books/">Books</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_section == 'end_users' %} active{% endif %}" href="/sections/end_users"{% if nav_section == 'end_users' %} aria-current="page"{% endif %}>End users</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_section == 'hacking' %} active{% endif %}" href="/sections/hacking"{% if nav_section == 'hacking' %} aria-current="page"{% endif %}>Hacking</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_section == 'humour' %} active{% endif %}" href="/sections/humour"{% if nav_section == 'humour' %} aria-current="page"{% endif %}>Humour</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_section == 'interviews' %} active{% endif %}" href="/sections/interviews"{% if nav_section == 'interviews' %} aria-current="page"{% endif %}>Interviews</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_section == 'opinions' %} active{% endif %}" href="/sections/opinions"{% if nav_section == 'opinions' %} aria-current="page"{% endif %}>Opinons</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_section == 'reviews' %} active{% endif %}" href="/sections/reviews"{% if nav_section == 'reviews' %} aria-current="page"{% endif %}>Reviews</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_url contains '/all_articles/' %} active{% endif %}" href="/all_articles/"{% if nav_url contains '/all_articles/' %} aria-current="page"{% endif %}>All articles</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_url contains '/issues/' %} active{% endif %}" href="/issues/"{% if nav_url contains '/issues/' %} aria-current="page"{% endif %}>Issues</a></li>
+      <li class="nav-item"><a class="nav-link{% if nav_url contains '/books/' %} active{% endif %}" href="/books/"{% if nav_url contains '/books/' %} aria-current="page"{% endif %}>Books</a></li>
     </ul>
   </div>
 </nav>

--- a/_includes/paginated_article_list.html
+++ b/_includes/paginated_article_list.html
@@ -2,16 +2,31 @@
   <h3 class="text-center mb-4">{{ page.list_title }}</h3>
 {% endif %}
 
-{% if page.list_photo_url %}
-  <p class="text-center">
-    <img class="img-fluid rounded mb-3" src="{{ page.list_photo_url }}" alt="{{ page.list_title }}" style="max-width: 220px;">
-  </p>
-{% endif %}
+{% if page.list_name == "authors" and (page.list_photo_url or page.list_description) %}
+  <section class="author-bio-box mb-4" aria-label="Author profile">
+    {% if page.list_photo_url %}
+      <div class="author-bio-photo">
+        <img class="img-fluid rounded" src="{{ page.list_photo_url }}" alt="{{ page.list_title }}">
+      </div>
+    {% endif %}
+    {% if page.list_description %}
+      <div class="author-bio-content">
+        {{ page.list_description }}
+      </div>
+    {% endif %}
+  </section>
+{% else %}
+  {% if page.list_photo_url %}
+    <p class="text-center">
+      <img class="img-fluid rounded mb-3" src="{{ page.list_photo_url }}" alt="{{ page.list_title }}" style="max-width: 220px;">
+    </p>
+  {% endif %}
 
-{% if page.list_description %}
-  <div class="mb-4">
-    {{ page.list_description }}
-  </div>
+  {% if page.list_description %}
+    <div class="mb-4">
+      {{ page.list_description }}
+    </div>
+  {% endif %}
 {% endif %}
 
 {% if page.list_name == "books" %}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -27,6 +27,78 @@
   text-align: center;
 }
 
+.article-content table {
+  border: 1px solid #d7e5ef;
+  border-collapse: collapse;
+  margin: 1.35rem 0 0.35rem;
+  width: 100%;
+}
+
+.article-content table th,
+.article-content table td {
+  border: 1px solid #d7e5ef;
+  line-height: 1.45;
+  padding: 0.44rem 0.58rem;
+  vertical-align: top;
+}
+
+.article-content table thead th {
+  background: #eff6fb;
+  color: #2b3c4a;
+  font-weight: 600;
+}
+
+.article-content table tbody tr:nth-child(even) {
+  background: #fbfdff;
+}
+
+.article-content table thead.fsm-legacy-empty-head {
+  display: none;
+}
+
+.article-content table thead.fsm-legacy-empty-head + tbody tr:first-child td {
+  background: #eff6fb;
+  color: #2b3c4a;
+  font-weight: 600;
+}
+
+.article-content .table-caption {
+  color: #5e7485;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  margin: 0.38rem 0 1.2rem;
+}
+
+.author-bio-box {
+  align-items: flex-start;
+  background: linear-gradient(180deg, #f8fcff 0%, #eef6fc 100%);
+  border: 1px solid #d5e4ef;
+  border-radius: 0.6rem;
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.author-bio-photo {
+  flex: 0 0 150px;
+}
+
+.author-bio-photo img {
+  border: 1px solid #c8d9e6;
+  box-shadow: 0 2px 7px rgba(30, 61, 86, 0.16);
+  display: block;
+  width: 100%;
+}
+
+.author-bio-content {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.author-bio-content > :last-child {
+  margin-bottom: 0;
+}
+
 .article-hero {
   display: block;
   float: right;
@@ -50,12 +122,27 @@
 }
 
 @media (max-width: 767px) {
+  .author-bio-box {
+    flex-direction: column;
+  }
+
+  .author-bio-photo {
+    flex: 0 0 auto;
+    max-width: 170px;
+  }
+
   .article-hero {
     float: none;
     margin: 0 0 1rem;
     max-width: 100%;
     min-width: 0;
     width: 100%;
+  }
+
+  .article-content table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
   }
 }
 
@@ -104,6 +191,23 @@
   margin-left: 1rem;
   text-transform: uppercase;
   white-space: nowrap;
+}
+
+.navbar-clear .nav-link.active {
+  color: #2a7eaf;
+  font-weight: 700;
+  position: relative;
+}
+
+.navbar-clear .nav-link.active::after {
+  background: #2a7eaf;
+  border-radius: 2px;
+  bottom: -0.12rem;
+  content: "";
+  height: 2px;
+  left: 0.35rem;
+  position: absolute;
+  right: 0.35rem;
 }
 
 .book-nav {


### PR DESCRIPTION
## Summary
- fix legacy and standard article table readability with proper styling
- detect legacy blank-header tables post-render and style first body row as header
- highlight active top navigation items based on current section/page
- improve books listing row presentation

## Notes
- .last-run.json is not included
- test-results/ remains untracked and is not part of this PR