### PR TITLE
Fix desktop nav orientation regression

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -131,6 +131,7 @@
 .fsm-nav-links {
   align-items: center;
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- fix top navigation on desktop rendering vertically after Bootstrap migration
- force .fsm-nav-links to flex-direction: row in custom CSS

## Scope
- single file change: assets/css/custom.css
- no changes under articles/