### PR TITLE
Remove fsmsh permalink from article template

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -37,12 +37,6 @@
         {% endif %}
       </li>
       <li class="list-inline-item">{{ page.published | date: "%-m/%-d/%Y" }}</li>
-      {% assign article_nid = page.nid | default: "" | strip %}
-      {% if article_nid != "" %}
-        <li class="list-inline-item">
-          <a href="http://fsmsh.com/{{ article_nid }}">Permalink</a>
-        </li>
-      {% endif %}
       {% if page.tags %}
         <li class="list-inline-item">
           Tags:


### PR DESCRIPTION
Removes the legacy fsmsh permalink from the article layout template.